### PR TITLE
ci: Add deploy workflows for docker build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,7 @@ jobs:
           go-version: '1.21.x'
       - run: make compile
       - run: make test
+      - run: make docker
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,73 @@
+on: [push]
+
+env:
+  REGISTRY_IMAGE: ghcr.io/raeperd/go-http-template
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        id: build
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.21-bullseye as builder
+WORKDIR /src
+COPY . /src
+RUN make compile TARGET_EXEC=app CGO_ENABLED=0 
+
+FROM scratch
+COPY --from=builder /src/app /bin/app
+ENTRYPOINT ["/bin/app"]
+CMD ["--port=8080"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 TARGET_EXEC := app
+PORT := 8080
+IMAGE := ghcr.io/raeperd/go-http-template
+TAG := local
 
-all: compile test lint 
+all: compile test lint docker
 
 compile:
 	go build -o $(TARGET_EXEC) . 
@@ -11,9 +14,15 @@ test:
 lint:
 	golangci-lint run
 
-run: PORT := 8080
 run: compile
 	./$(TARGET_EXEC) --port=$(PORT)
 
+docker:
+	docker build . -t $(IMAGE):$(TAG)
+
+docker-run: docker 
+	docker run --rm -p $(PORT):8080 $(IMAGE):$(TAG)
+
 clean:
 	rm $(TARGET_EXEC)
+	docker image rm $(IMAGE):$(TAG)


### PR DESCRIPTION
## Issue 
- Docker image must be built for modern go services
- with arm64 for apple silicon mac os

## Changed
- Add deploy workflow with multi platform docker build 
- Add `docker`, `docker-run` target for Makefile

## Reference 
- [Multi-platform image with GitHub Actions | Docker Docs](https://docs.docker.com/build/ci/github-actions/multi-platform/)